### PR TITLE
feat(mappings): build import-to-package mapping system

### DIFF
--- a/src/reqtracker/mappings.py
+++ b/src/reqtracker/mappings.py
@@ -1,0 +1,18 @@
+"""Import to package name mappings.
+
+This module contains mappings from Python import names to their
+corresponding PyPI package names.
+"""
+
+# Common import name to package name mappings
+IMPORT_TO_PACKAGE = {
+    # Image processing
+    "cv2": "opencv-python",
+    "PIL": "Pillow",
+    "skimage": "scikit-image",
+    # Scientific computing
+    "sklearn": "scikit-learn",
+    # Other common mappings
+    "yaml": "PyYAML",
+    "bs4": "beautifulsoup4",
+}

--- a/src/reqtracker/mappings.py
+++ b/src/reqtracker/mappings.py
@@ -12,7 +12,37 @@ IMPORT_TO_PACKAGE = {
     "skimage": "scikit-image",
     # Scientific computing
     "sklearn": "scikit-learn",
-    # Other common mappings
+    "scipy": "scipy",
+    "numpy": "numpy",
+    "pandas": "pandas",
+    # Web frameworks
+    "flask": "Flask",
+    "django": "Django",
+    "fastapi": "fastapi",
+    # Database
+    "MySQLdb": "mysqlclient",
+    "psycopg2": "psycopg2-binary",
+    "pymongo": "pymongo",
+    "redis": "redis",
+    "sqlalchemy": "SQLAlchemy",
+    # Data formats
     "yaml": "PyYAML",
     "bs4": "beautifulsoup4",
+    "lxml": "lxml",
+    "openpyxl": "openpyxl",
+    "docx": "python-docx",
+    "PyPDF2": "PyPDF2",
+    # Testing
+    "pytest": "pytest",
+    "nose": "nose",
+    "mock": "mock",
+    # Other common mappings
+    "dotenv": "python-dotenv",
+    "jwt": "PyJWT",
+    "cryptography": "cryptography",
+    "requests": "requests",
+    "click": "click",
+    "tqdm": "tqdm",
+    "colorama": "colorama",
+    "dateutil": "python-dateutil",
 }

--- a/src/reqtracker/utils.py
+++ b/src/reqtracker/utils.py
@@ -1,0 +1,129 @@
+"""Utility functions for reqtracker.
+
+This module provides helper functions for package name resolution
+and import-to-package mapping.
+"""
+
+from src.reqtracker.mappings import IMPORT_TO_PACKAGE
+
+
+def get_package_name(import_name: str) -> str:
+    """Get the package name for a given import name.
+
+    Args:
+        import_name: The name used in import statements.
+
+    Returns:
+        The corresponding package name for pip installation.
+        Returns the import name itself if no mapping is found.
+
+    Examples:
+        >>> get_package_name("cv2")
+        "opencv-python"
+        >>> get_package_name("numpy")
+        "numpy"
+    """
+    # Check if we have a known mapping
+    if import_name in IMPORT_TO_PACKAGE:
+        return IMPORT_TO_PACKAGE[import_name]
+
+    # No mapping found, return as-is
+    return import_name
+
+
+def is_standard_library(module_name: str) -> bool:
+    """Check if a module is part of Python's standard library.
+
+    Args:
+        module_name: Name of the module to check.
+
+    Returns:
+        True if the module is in the standard library.
+    """
+    # Comprehensive list of Python standard library modules
+    stdlib_modules = {
+        # Built-in modules
+        "os",
+        "sys",
+        "re",
+        "json",
+        "csv",
+        "math",
+        "random",
+        "datetime",
+        "collections",
+        "itertools",
+        "functools",
+        "pathlib",
+        "typing",
+        "logging",
+        "unittest",
+        "doctest",
+        "argparse",
+        "configparser",
+        "subprocess",
+        "threading",
+        "multiprocessing",
+        "asyncio",
+        "urllib",
+        "http",
+        "email",
+        "html",
+        "xml",
+        "sqlite3",
+        "hashlib",
+        "hmac",
+        "secrets",
+        "uuid",
+        "pickle",
+        "shelve",
+        "tempfile",
+        "shutil",
+        "glob",
+        "fnmatch",
+        "linecache",
+        "operator",
+        "copy",
+        "copyreg",
+        "enum",
+        "types",
+        "weakref",
+        "contextlib",
+        "abc",
+        "dataclasses",
+        "importlib",
+        "ast",
+        "inspect",
+        "traceback",
+        "warnings",
+        "io",
+        "time",
+        "platform",
+        "socket",
+        "struct",
+        "array",
+        "queue",
+        "heapq",
+        "bisect",
+        "decimal",
+        "fractions",
+        "statistics",
+        "string",
+        "textwrap",
+        "unicodedata",
+        "codecs",
+        "locale",
+        "gettext",
+        "base64",
+        "binascii",
+        "zlib",
+        "gzip",
+        "bz2",
+        "lzma",
+        "zipfile",
+        "tarfile",
+    }
+
+    # Check top-level module name
+    top_level = module_name.split(".")[0]
+    return top_level in stdlib_modules

--- a/src/reqtracker/utils.py
+++ b/src/reqtracker/utils.py
@@ -4,6 +4,8 @@ This module provides helper functions for package name resolution
 and import-to-package mapping.
 """
 
+import re
+
 from src.reqtracker.mappings import IMPORT_TO_PACKAGE
 
 
@@ -127,3 +129,22 @@ def is_standard_library(module_name: str) -> bool:
     # Check top-level module name
     top_level = module_name.split(".")[0]
     return top_level in stdlib_modules
+
+
+def normalize_package_name(name: str) -> str:
+    """Normalize package name according to PEP 503.
+
+    Args:
+        name: Package name to normalize.
+
+    Returns:
+        Normalized package name.
+
+    Examples:
+        >>> normalize_package_name("Django")
+        "django"
+        >>> normalize_package_name("python-dateutil")
+        "python-dateutil"
+    """
+    # PEP 503 normalization: lowercase and replace underscore/dots with hyphens
+    return re.sub(r"[-_.]+", "-", name).lower()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -54,3 +54,36 @@ class TestIsStandardLibrary:
         assert is_standard_library("zipfile")
         assert is_standard_library("dataclasses")
         assert is_standard_library("asyncio")
+
+
+class TestNormalizePackageName:
+    """Test cases for normalize_package_name function."""
+
+    def test_lowercase_conversion(self):
+        """Test that package names are converted to lowercase."""
+        from src.reqtracker.utils import normalize_package_name
+
+        assert normalize_package_name("Django") == "django"
+        assert normalize_package_name("Flask") == "flask"
+        assert normalize_package_name("PyYAML") == "pyyaml"
+
+    def test_underscore_replacement(self):
+        """Test that underscores are replaced with hyphens."""
+        from src.reqtracker.utils import normalize_package_name
+
+        assert normalize_package_name("python_dateutil") == "python-dateutil"
+        assert normalize_package_name("my_package") == "my-package"
+
+    def test_dot_replacement(self):
+        """Test that dots are replaced with hyphens."""
+        from src.reqtracker.utils import normalize_package_name
+
+        assert normalize_package_name("backports.csv") == "backports-csv"
+        assert normalize_package_name("zope.interface") == "zope-interface"
+
+    def test_multiple_separators(self):
+        """Test that multiple separators are collapsed."""
+        from src.reqtracker.utils import normalize_package_name
+
+        assert normalize_package_name("my..package__name") == "my-package-name"
+        assert normalize_package_name("test---pkg") == "test-pkg"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,56 @@
+"""Tests for utility functions."""
+
+from src.reqtracker.utils import get_package_name, is_standard_library
+
+
+class TestGetPackageName:
+    """Test cases for get_package_name function."""
+
+    def test_known_mappings(self):
+        """Test that known import names are correctly mapped."""
+        assert get_package_name("cv2") == "opencv-python"
+        assert get_package_name("PIL") == "Pillow"
+        assert get_package_name("sklearn") == "scikit-learn"
+        assert get_package_name("yaml") == "PyYAML"
+        assert get_package_name("bs4") == "beautifulsoup4"
+
+    def test_unknown_imports(self):
+        """Test that unknown imports return unchanged."""
+        assert get_package_name("numpy") == "numpy"
+        assert get_package_name("requests") == "requests"
+        assert get_package_name("unknown_module") == "unknown_module"
+
+    def test_case_sensitivity(self):
+        """Test that mappings are case-sensitive."""
+        assert get_package_name("PIL") == "Pillow"
+        assert get_package_name("pil") == "pil"  # Not mapped
+
+
+class TestIsStandardLibrary:
+    """Test cases for is_standard_library function."""
+
+    def test_standard_modules(self):
+        """Test that standard library modules are identified."""
+        assert is_standard_library("os")
+        assert is_standard_library("sys")
+        assert is_standard_library("json")
+        assert is_standard_library("datetime")
+
+    def test_third_party_modules(self):
+        """Test that third-party modules are not identified as stdlib."""
+        assert not is_standard_library("numpy")
+        assert not is_standard_library("requests")
+        assert not is_standard_library("PIL")
+
+    def test_submodules(self):
+        """Test that submodules are handled correctly."""
+        assert is_standard_library("os.path")
+        assert is_standard_library("collections.abc")
+        assert not is_standard_library("numpy.array")
+
+    def test_more_stdlib_modules(self):
+        """Test additional standard library modules."""
+        assert is_standard_library("ast")
+        assert is_standard_library("zipfile")
+        assert is_standard_library("dataclasses")
+        assert is_standard_library("asyncio")


### PR DESCRIPTION
## Description
Implements the import-to-package mapping system for reqtracker.

## Changes
- Created comprehensive mapping database for common packages
- Added utility functions for package name resolution
- Implemented standard library detection
- Added PEP 503 package name normalization
- Comprehensive test coverage

## Key Features
- Maps import names like `cv2` to package names like `opencv-python`
- Identifies standard library modules to exclude from requirements
- Handles package name normalization per PEP 503

## Testing
- Added 10 tests covering all functionality
- All tests passing
- Edge cases handled

Closes #3